### PR TITLE
Make it possible to display absolute time stamps (since midnight)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,31 @@ Here is what a recorder dump can look like (lines omitted for brevity):
     recorder_test.c:169: [198750795 10.003122] MAIN:   Record cost     =         50ns
 
 Lines begin with the source code location in the program where the
-record was taken. The number following the source location is the
-*order* of records, a global sequence number that helps relate records
-made in different recorders or from different threads.
+record was taken. This is optional, and is under control of a recorder
+tweak called `recorder_location`. Another tweak, `recorder_functions`,
+selects whether that location includes the function name.
+
+The number following the source location is the *order* of records, a
+global sequence number that helps relate records made in different
+recorders or from different threads. The display of the order can be
+configured using the `recorder_order` tweak.
+
 The order is followed by a *timestamp*, which counds the number of
-seconds since the start of the program. On 32-bit machines,
-the timestamp is precise to the ms. On 64-bit machines, it is precise to the
-microsecond. Finally, the rest of the record is a printout of what was
-recorded.
+seconds since the start of the program. On 32-bit machines, the
+timestamp is precise to the ms. On 64-bit machines, it is precise to
+the microsecond. The time stamp can be displayed as absolute time
+since midnight using the `recorder_abstime` tweak. The relative
+time can be disabled by setting `recorder_reltime` tweak to 0.
+With `recorder_abstime=1 recorder_reltime=0`, the recorder dump will
+look as follows:
+
+     [11 09:06:16.718056] recorder: Activating tweak 'recorder_abstime' (0x10cba0910)
+     [12 09:06:16.718062] recorder: Activating 'MAIN' (0x10cb84148)
+     [13 09:06:16.718062] recorder: Activating 'Pauses' (0x10cb851b8)
+     [14 09:06:16.718063] recorder: Activating 'Special' (0x10cb89228)
+     [15 09:06:16.718063] recorder: Activating 'SpeedTest' (0x10cb8a298)
+
+Finally, the rest of the record is a printout of what was recorded.
 
 The recorder dump is generally sorted according to order and should
 show time stamps in increasing order. However, as the example above

--- a/recorder.c
+++ b/recorder.c
@@ -62,16 +62,9 @@
 
 // ============================================================================
 //
-//   Available recorders exposed by recorder library
+//    File-specific constants
 //
 // ============================================================================
-
-RECORDER(recorder,              32, "Recorder operations and configuration");
-RECORDER(recorder_warning,       8, "Recorder warnings");
-RECORDER(recorder_error,         8, "Recorder errors");
-RECORDER(recorder_signals,      32, "Recorder signal handling");
-RECORDER(recorder_traces,       64, "Recorder traces");
-
 
 enum
 {
@@ -117,9 +110,34 @@ enum
 #endif // SIGPWR
 };
 
+
+
+// ============================================================================
+//
+//   Available recorders exposed by recorder library
+//
+// ============================================================================
+
+RECORDER(recorder,              32, "Recorder operations and configuration");
+RECORDER(recorder_warning,       8, "Recorder warnings");
+RECORDER(recorder_error,         8, "Recorder errors");
+RECORDER(recorder_signals,      32, "Recorder signal handling");
+RECORDER(recorder_traces,       64, "Recorder traces");
+
+
 RECORDER_TWEAK_DEFINE(recorder_signals_mask,
                       RECORDER_SIGNALS_MASK,
                       "Recorder default mask for signals to catch");
+RECORDER_TWEAK_DEFINE(recorder_location, 0,
+                      "Set to show location in recorder dumps");
+RECORDER_TWEAK_DEFINE(recorder_function, 0,
+                      "Set to show function in recorder dumps");
+RECORDER_TWEAK_DEFINE(recorder_dump_sleep, 100,
+                      "Sleep time between background dumps (ms)");
+RECORDER_TWEAK_DEFINE(recorder_export_size, 2048,
+                      "Number of samples stored when exporting records");
+RECORDER_TWEAK_DEFINE(recorder_configuration_sleep, 100,
+                      "Sleep time between configuration checks (ms)");
 
 
 
@@ -778,11 +796,6 @@ recorder_show_fn  recorder_configure_show(recorder_show_fn show)
 #if defined(_MSC_VER) && _MSC_VER < 1900
 #  define snprintf  _snprintf
 #endif
-
-RECORDER_TWEAK_DEFINE(recorder_location, 0,
-                      "Set to show location in recorder dumps");
-RECORDER_TWEAK_DEFINE(recorder_function, 0,
-                      "Set to show function in recorder dumps");
 
 static void recorder_format_entry(recorder_show_fn show,
                                   void *output,
@@ -1767,9 +1780,6 @@ static recorder_type recorder_type_from_format(const char *format,
 //
 // ============================================================================
 
-RECORDER_TWEAK_DEFINE(recorder_dump_sleep, 100,
-                      "Sleep time between background dumps (ms)");
-
 static bool background_dump_running = false;
 
 
@@ -2019,8 +2029,6 @@ void recorder_tweak_activate (recorder_tweak *tweak)
 //
 // ============================================================================
 
-RECORDER_TWEAK_DEFINE(recorder_export_size, 2048,
-                      "Number of samples stored when exporting records");
 static recorder_chans_p chans = NULL;
 
 static const char *recorder_type_name[] =
@@ -2103,8 +2111,6 @@ static void recorder_atexit_cleanup(void)
 }
 
 
-RECORDER_TWEAK_DEFINE(recorder_configuration_sleep, 100,
-                      "Sleep time between configuration checks (ms)");
 static void *background_configuration_check(void *ignored)
 // ----------------------------------------------------------------------------
 //    Check if there is a configuration command and apply it


### PR DESCRIPTION
Three tweaks were added:

* `recorder_order` enables / disable the display of the order
* `recorder_abstime` enables / disables the display of absolute time
* `recorder_reltime` enables / dsiables the display of relative time

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>
Suggested-by: Frediano Ziglio <fzliglio@redhat.com>